### PR TITLE
Capitalization consistency fixes

### DIFF
--- a/source/_footer.haml
+++ b/source/_footer.haml
@@ -3,7 +3,7 @@
     .row
       .col-lg-3.col-lg-offset-1
         %a.navbar-brand.page-scroll{:href => "#page-top"} 
-          =image_tag 'img/logo.svg', :title => 'Flatpack', :class => 'full'
+          =image_tag 'img/logo.svg', :title => 'Flatpak', :class => 'full'
       %ul.col-lg-7
         - data.menu.each do |i|
           %li.toplevel

--- a/source/developer.html.haml.markdown
+++ b/source/developer.html.haml.markdown
@@ -1,10 +1,10 @@
 <section class="bg-dark"><div class="container"><div class="row"><div class="col-lg-10 col-lg-offset-1">
 :markdown
-  # Getting Started with flatpak
+  # Getting Started with Flatpak
 
-  This guide contains everything you need to know to build and distribute applications using flatpak. It includes an introduction to the basic concepts and a simple app building tutorial, before moving on to cover automated building and repository hosting.
+  This guide contains everything you need to know to build and distribute applications using Flatpak. It includes an introduction to the basic concepts and a simple app building tutorial, before moving on to cover automated building and repository hosting.
 
-  Example tutorials are used throughout this guide. To complete them, it is necessary to have flatpak and flat-pak-builder installed on your system. See [getting flatpak](getting.html) for more details on this.
+  Example tutorials are used throughout this guide. To complete them, it is necessary to have flatpak and flatpak-builder installed on your system. See [getting Flatpak](getting.html) for more details on this.
 
   ### Table of Contents
 
@@ -19,7 +19,7 @@
   <a name="KeyConcepts"></a>
   ## Key Concepts
 
-  Flatpak is best understood through its key concepts: runtimes, bundles, SDKs and sandboxes. These help to explain how flatpak differs from traditional application distribution on Linux, as well as the framework's capabilities.
+  Flatpak is best understood through its key concepts: runtimes, bundles, SDKs and sandboxes. These help to explain how Flatpak differs from traditional application distribution on Linux, as well as the framework's capabilities.
 
   ### Runtimes
 
@@ -41,7 +41,7 @@
 
   ### Sandboxes
 
-  With flatpak, each app is built and run in an isolated environment. By default, the application can only 'see' itself and its runtime. Access to user files, network, graphics sockets, subsystems on the bus and devices all has to be explicitly granted. (As will be described later, flatpak provides several ways to do this.) Access to other things, such as other processes, is (deliberately) not possible.
+  With Flatpak, each app is built and run in an isolated environment. By default, the application can only 'see' itself and its runtime. Access to user files, network, graphics sockets, subsystems on the bus and devices all has to be explicitly granted. (As will be described later, Flatpak provides several ways to do this.) Access to other things, such as other processes, is (deliberately) not possible.
 
   <a name="TheFlatpakCommand"></a>
   ## The flatpak Command
@@ -51,7 +51,7 @@
   <a name="AppAnatomy"></a>
   ## Anatomy of a Flatpak App
 
-  Each flatpak app has the following basic structure:
+  Each Flatpak app has the following basic structure:
 
       metadata    # A keyfile which provides information about the application,
                   # including information that is necessary for setting up the sandbox
@@ -94,7 +94,7 @@
   <a name="BuildingSimpleApps"></a>
   ## Building Simple Apps
 
-  `flatpak` provides a simple set of tools for building and distributing applications. These allow creating new flatpaks, into which new or existing applications can be built. This section describes how to build a simple application which doesn't require any additional dependencies outside of the runtime it is built against.
+  The `flatpak` utility provides a simple set of commands for building and distributing applications. These allow creating new Flatpaks, into which new or existing applications can be built. This section describes how to build a simple application which doesn't require any additional dependencies outside of the runtime it is built against.
 
   ### Installing an SDK
 
@@ -178,13 +178,13 @@
   <a name="ComplexAppsWithFlatpakBuilder"></a>
   ## Building More Complex Apps With flatpak-builder
 
-  If an application requires additional dependencies that aren't provided by its runtime, flatpak allows them to be bundled as modules as part of the app itself. This requires building each module inside the application, which can be a lot of work. For this reason, the flatpak-builder tool is provided to automate the build process.
+  If an application requires additional dependencies that aren't provided by its runtime, Flatpak allows them to be bundled as modules as part of the app itself. This requires building each module inside the application, which can be a lot of work. The `flatpak-builder` tool can automate this multi-step build process.
 
   flatpak-builder takes care of the routine commands used to build an app and any bundled modules, thus allowing application building to be automated. To do this, it expects modules to be built in a standard manner by following what is called the [Build API](https://github.com/cgwalters/build-api). If any modules don't conform to this API, they will need to be modified.
 
   ### Manifests
 
-  flatpak-builder uses a json file to describe the parameters for building an app, as well as each of the modules to be bundled. This file is called the manifest. Module sources can be of several types, including archives (`.tar`, `.zip`), Git, Bzr, patch files or shell commands that are run.
+  The input to flatpak-builder is a json file that describes the parameters for building an app, as well as each of the modules to be bundled. This file is called the manifest. Module sources can be of several types, including .tar or .zip archives, Git or Bzr repositories, patch files or shell commands that are run.
 
   The GNOME Dictionary manifest is short, because the only module is the application itself:
 

--- a/source/faq.html.haml.markdown
+++ b/source/faq.html.haml.markdown
@@ -3,15 +3,15 @@
 
   # Frequently Asked Questions
 
-  ### Why the name flatpak?
+  ### Why the name Flatpak?
 
   IKEA is a world-wide known brand whose success was partly built upon having developed and refined the idea of flatpacking
   their furniture, which allowed them huge cost savings and efficiencies compared to their competitors. So when we needed
-  a new name for the packaging technology that had been developed by Alex Larsson, a native Swede, we thought that flatpak would
+  a new name for the packaging technology that had been developed by Alex Larsson, a native Swede, we thought that Flatpak would
   both be a nice play on his nationality and pay homage to the success of IKEA and at the same time send a strong signal
   about how revolutionary we thought this new packaging technology could be for the Linux desktop.
 
-  ### What is the origin of the flatpak technology?
+  ### What is the origin of the Flatpak technology?
 
   Flatpak is a technology that brings toghether many of the lessons learned by its creator Alexander Larsson during his long tenure
   as a Linux desktop developer and having spent time inside Red Hat working on container technologies. Flatpak builds upon existing
@@ -19,26 +19,26 @@
   and the OCI format that is developed by the [Open Container Initiative](https://www.opencontainers.org/).
   It has also spawned new technologies such as Bubblewrap which is shared between Flatpak and Project Atomic.
 
-  ### Is flatpak tied to GNOME? Is it tied to Fedora?
+  ### Is Flatpak tied to GNOME? Is it tied to Fedora?
 
-  No. While flatpak has been developed by people with a long involvement in the GNOME and Fedora communities it is not tied
-  to either, in fact it was designed with the explicit goal of allowing it to build applications using any library stack or
+  No. While Flatpak has been developed by people with a long involvement in the GNOME and Fedora communities it is not tied
+  to either. In fact, it was designed with the explicit goal of allowing it to build applications using any library stack or
   programming language an application author might want. At the same it was also built to be distribution agnostic and
-  allow deployment on any Linux operating system out there, in fact we made sure to reach out and discuss flatpak with
-  representatives of other distributions from very early on in the project.
+  allow deployment on any Linux operating system out there. We've reached out and discussed Flatpak with representatives of other
+  distributions from very early on in the project.
 
-  ### Is flatpak the same as xdg-app?
+  ### Is Flatpak the same as xdg-app?
 
   Yes, while xdg-app was a fine name to use during development we wanted something with wider appeal and more sparkle
-  to it than xdg-app could provide. So as part of formally launching flatpak as ready for use we decided to pick a new
-  and more accessible and fun name.
+  to it than xdg-app could provide. So as part of formally launching Flatpak as ready for use we decided to pick a more accessible
+  and fun name.
 
-  ### Is flatpak a container technology?
+  ### Is Flatpak a container technology?
 
   It can be, but it doesn't have to be. Since a desktop application would require quite extensive changes in order to
-  be usable when run inside a container you will likely see flatpak mostly deployed as a convenient library bundling technology
+  be usable when run inside a container you will likely see Flatpak mostly deployed as a convenient library bundling technology
   early on, with the sandboxing or containerization being phased in over time for most applications. In general though we
-  try to avoid using the term container when speaking about flatpak as it tends to cause comparisons with Docker and Rocket,
+  try to avoid using the term container when speaking about Flatpak as it tends to cause comparisons with Docker and Rocket,
   comparisons which quickly stop making technical sense due to the very different problem spaces these technologies
   try to address. And thus we prefer using the term sandboxing.
 

--- a/source/getting.html.haml.markdown
+++ b/source/getting.html.haml.markdown
@@ -1,16 +1,16 @@
 <section class=""><div class="container"><div class="row"><div class="col-lg-10 col-lg-offset-1">
 :markdown
-  # Getting flatpak
+  # Getting Flatpak
 
-  flatpak is available for the most common Linux distributions.
+  Flatpak is available for the most common Linux distributions.
 
   ### Fedora
 
-  `flatpak` is available for Fedora from version 22.
+  A `flatpak` package is available for Fedora from version 22.
 
   ### Ubuntu
 
-  `flatpak` is available for Ubuntu 14.04, 15.04, 15.10 and 16.04 using a PPA. To install, run:
+  A `flatpak` package is available for Ubuntu 14.04, 15.04, 15.10 and 16.04 using a PPA. To install, run:
 
       sudo add-apt-repository ppa:alexlarsson/flatpak
       sudo apt-get update
@@ -18,14 +18,14 @@
 
   ### Debian
 
-  A custom apt repository is available for Debian Jesse. To install, run the following as root:
+  A custom apt repository is available for Debian Jessie. To install, run the following as root:
 
       wget -O - https://sdk.gnome.org/apt/debian/conf/alexl.gpg.key|apt-key add -
       echo "deb [arch=amd64] https://sdk.gnome.org/apt/debian/ jessie main" > /etc/apt/sources.list.d/flatpak.list
       apt update
       apt install flatpak
 
-  This will install flatpak, but by default Debian disallows user-namespaces as non-root, which means flatpak will not work. To enable this run:
+  This will install Flatpak, but by default Debian disallows user-namespaces as non-root, which means Flatpak will not work. To enable this run:
 
       sysctl kernel.unprivileged_userns_clone=1
 
@@ -35,10 +35,10 @@
 
   ### Arch
 
-  `flatpak` is available in the AUR.
+  A `flatpak` package is available in the AUR.
 
   ### Mageia
 
-  `flatpak` is available in Cauldron.
+  A `flatpak` package is available in Cauldron.
 
 </div></div></div></section>

--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -77,16 +77,16 @@
           Before you can install applications with Flatpak, you need to install
           Flatpak itself. Currently this has to be done using the command line.
           This section contains instructions for installing Flatpak on Fedora or Ubuntu.
-          Details on how to install flatpak on other distros are available on the 
-          = succeed "." do
-            %a{:href => "getting.html"} getting flatpak page
+          Details on how to install Flatpak on other distros are available on the 
+          %a{:href => "getting.html"} getting Flatpak
+          page.
         %p
           With Fedora, run:
         %pre
           :preserve
             $ sudo dnf install flatpak
         %p
-          On Ubuntu, flatpak is available through a PPA. To install it, run:
+          On Ubuntu, Flatpak is available through a PPA. To install it, run:
         %pre
           :preserve
             $ sudo add-apt-repository ppa:alexlarsson/flatpak
@@ -123,7 +123,7 @@
           :preserve
             $ flatpak --user install gnome-apps org.gnome.gedit stable
         %p
-          Installed applications should appear in the usual place. You can also run them from the command line:
+          Installed applications should appear in the usual place in your desktop. You can also run them from the command line:
         %pre
           :preserve
             $ flatpak run org.gnome.gedit stable
@@ -146,16 +146,16 @@
           =link_to 'developers page.', 'developer.html'
         %h3 1. Install Flatpak
         %p
-          First we need to install Flatpak itself. The instructions here are for Fedora or Ubuntu
+          First we need to install Flatpak itself. The instructions here are for Fedora or Ubuntu.
           Details for other distros can be found on the
-          = succeed "." do
-            %a{:href => "getting.html"} getting flatpak page
+          %a{:href => "getting.html"} getting Flatpak
+          page.
           If you are using Fedora, run:
         %pre
           :preserve
             $ sudo dnf install flatpak
         %p
-          On Ubuntu, flatpak is available through a PPA. To install it, run:
+          On Ubuntu, Flatpak is available through a PPA. To install it, run:
         %pre
           :preserve
             $ sudo add-apt-repository ppa:alexlarsson/flatpak
@@ -165,7 +165,7 @@
         %p
           Flatpak requires every app to specify a runtime that it uses for its dependencies.
           We'll use the GNOME 3.20 development platform runtime for this. To install the runtime, 
-          we first need to add the repository that provides it. To do this, run:
+          we first need to add the repository that provides it. Run:
         %pre
           :preserve
             $ wget https://sdk.gnome.org/keys/gnome-sdk.gpg
@@ -241,7 +241,7 @@
             %em Hello world, from a sandbox
         %p
           Ta da! That's it: you've successfully built, installed and run your first Flatpak. Many 
-          of these steps are simplified by flatpak's built in tools. For information on how to use 
+          of these steps are simplified by Flatpak's built in tools. For information on how to use 
           them, as well as how to build and distribute more complex apps 
           =link_to 'see the developers page.', 'developer.html'        
 %section#get-involved


### PR DESCRIPTION
Use Flatpak with a capital F unless we're talking about the
commandline utility, a package name or an application bundle.

A few other rewordings have snuck in here as well.